### PR TITLE
Make find() create BSON ObjectIds automatically - Fixes #9

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,8 @@ module.exports = function (grunt) {
           'mout/object/omit',
           'js-data',
           'js-data-schema',
-          'mongodb'
+          'mongodb',
+          'bson'
         ],
         module: {
           loaders: [

--- a/dist/js-data-mongodb.js
+++ b/dist/js-data-mongodb.js
@@ -53,17 +53,19 @@ module.exports =
 
 	var MongoClient = __webpack_require__(1).MongoClient;
 
-	var JSData = _interopRequire(__webpack_require__(2));
+	var ObjectID = __webpack_require__(2).ObjectID;
 
-	var underscore = _interopRequire(__webpack_require__(3));
+	var JSData = _interopRequire(__webpack_require__(3));
 
-	var keys = _interopRequire(__webpack_require__(4));
+	var underscore = _interopRequire(__webpack_require__(4));
 
-	var omit = _interopRequire(__webpack_require__(5));
+	var keys = _interopRequire(__webpack_require__(5));
 
-	var map = _interopRequire(__webpack_require__(6));
+	var omit = _interopRequire(__webpack_require__(6));
 
-	var isEmpty = _interopRequire(__webpack_require__(7));
+	var map = _interopRequire(__webpack_require__(7));
+
+	var isEmpty = _interopRequire(__webpack_require__(8));
 
 	var DSUtils = JSData.DSUtils;
 	var deepMixIn = DSUtils.deepMixIn;
@@ -246,6 +248,9 @@ module.exports =
 	          return new DSUtils.Promise(function (resolve, reject) {
 	            var params = {};
 	            params[resourceConfig.idAttribute] = id;
+	            if (resourceConfig.idAttribute === "_id" && typeof id === "string" && ObjectID.isValid(id)) {
+	              params[resourceConfig.idAttribute] = ObjectID.createFromHexString(id);
+	            }
 	            client.collection(resourceConfig.table || underscore(resourceConfig.name)).findOne(params, options, function (err, r) {
 	              if (err) {
 	                reject(err);
@@ -424,34 +429,40 @@ module.exports =
 /* 2 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = require("js-data");
+	module.exports = require("bson");
 
 /***/ },
 /* 3 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = require("mout/string/underscore");
+	module.exports = require("js-data");
 
 /***/ },
 /* 4 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = require("mout/object/keys");
+	module.exports = require("mout/string/underscore");
 
 /***/ },
 /* 5 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = require("mout/object/omit");
+	module.exports = require("mout/object/keys");
 
 /***/ },
 /* 6 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = require("mout/array/map");
+	module.exports = require("mout/object/omit");
 
 /***/ },
 /* 7 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = require("mout/array/map");
+
+/***/ },
+/* 8 */
 /***/ function(module, exports, __webpack_require__) {
 
 	module.exports = require("mout/lang/isEmpty");

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "bson": "^0.3.2",
     "mout": "0.11.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { MongoClient } from 'mongodb';
+import { ObjectID } from 'bson';
 import JSData from 'js-data';
 import underscore from 'mout/string/underscore';
 import keys from 'mout/object/keys';
@@ -179,6 +180,9 @@ class DSMongoDBAdapter {
       return new DSUtils.Promise((resolve, reject) => {
         let params = {};
         params[resourceConfig.idAttribute] = id;
+        if (resourceConfig.idAttribute === '_id' && typeof id === 'string' && ObjectID.isValid(id)) {
+            params[resourceConfig.idAttribute] = ObjectID.createFromHexString(id);
+        }
         client.collection(resourceConfig.table || underscore(resourceConfig.name)).findOne(params, options, (err, r) => {
           if (err) {
             reject(err);

--- a/test/find.spec.js
+++ b/test/find.spec.js
@@ -1,0 +1,40 @@
+describe('DSMongoDBAdapter#find', function () {
+  it('should find a user by its bson ObjectId hex string', function () {
+    var id;
+
+    return adapter.findAll(User, {
+      name: 'John'
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, { name: 'John' });
+    }).then(function (user) {
+      id = user._id;
+      return adapter.find(User, id.toString());
+    }).then(function (user) {
+      assert.deepEqual(user, { _id: id, name: 'John' });
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });
+
+  it('should not convert id if it is not a valid bson ObjectId hex string', function() {
+    var id;
+
+    return adapter.findAll(User, {
+      name: 'John'
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, { _id: 1, name: 'John' });
+    }).then(function (user) {
+      id = user._id;
+      assert.equal(typeof id, 'number');
+      return adapter.find(User, id);
+    }).then(function (user) {
+      assert.deepEqual(user, { _id: id, name: 'John' });
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });
+});


### PR DESCRIPTION
When the `resourceConfig.idAttribute` is `_id` and the value of `id` is
a valid BSON ObjectId hex string, then automatically convert the hex
string into a BSON ObjectId. This will make the MongoDb findOne call
successfully find objects by their BSON ObjectId.

This Fixes #9 
