### PR TITLE
Add support for contains query operator

### DIFF
--- a/dist/js-data-mongodb.js
+++ b/dist/js-data-mongodb.js
@@ -55,12 +55,12 @@ module.exports =
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-	var mongodb = __webpack_require__(2);
+	var mongodb = __webpack_require__(1);
 	var MongoClient = mongodb.MongoClient;
-	var bson = __webpack_require__(3);
-	var map = __webpack_require__(4);
+	var bson = __webpack_require__(2);
+	var map = __webpack_require__(3);
 	var ObjectID = bson.ObjectID;
-	var JSData = __webpack_require__(1);
+	var JSData = __webpack_require__(4);
 	var underscore = __webpack_require__(5);
 	var unique = __webpack_require__(6);
 	var DSUtils = JSData.DSUtils;
@@ -141,6 +141,8 @@ module.exports =
 	            } else if (op === '<=') {
 	              query[field] = query[field] || {};
 	              query[field].$lte = v;
+	            } else if (op === 'contains') {
+	              query[field] = new RegExp(v, 'i');
 	            } else if (op === 'in') {
 	              query[field] = query[field] || {};
 	              query[field].$in = v;
@@ -187,6 +189,11 @@ module.exports =
 	                '$lte': v
 	              };
 	              query.$or.push(orLteQuery);
+	            } else if (op === '|contains') {
+	              query.$or = query.$or || [];
+	              var orContainsQuery = {};
+	              orContainsQuery[field] = new RegExp(v, 'i');
+	              query.$or.push(orContainsQuery);
 	            } else if (op === '|in') {
 	              query.$or = query.$or || [];
 	              var orInQuery = {};
@@ -656,25 +663,25 @@ module.exports =
 /* 1 */
 /***/ function(module, exports) {
 
-	module.exports = require("js-data");
+	module.exports = require("mongodb");
 
 /***/ },
 /* 2 */
 /***/ function(module, exports) {
 
-	module.exports = require("mongodb");
+	module.exports = require("bson");
 
 /***/ },
 /* 3 */
 /***/ function(module, exports) {
 
-	module.exports = require("bson");
+	module.exports = require("mout/array/map");
 
 /***/ },
 /* 4 */
 /***/ function(module, exports) {
 
-	module.exports = require("mout/array/map");
+	module.exports = require("js-data");
 
 /***/ },
 /* 5 */

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "babel-core": "^5.8.23",
     "bson": "0.3.x",
     "mout": "0.11.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,8 @@ class DSMongoDBAdapter {
           } else if (op === '<=') {
             query[field] = query[field] || {};
             query[field].$lte = v;
+          } else if (op === 'contains') {
+            query[field] = new RegExp(v, 'i');
           } else if (op === 'in') {
             query[field] = query[field] || {};
             query[field].$in = v;
@@ -130,6 +132,11 @@ class DSMongoDBAdapter {
               '$lte': v
             };
             query.$or.push(orLteQuery);
+          } else if (op === '|contains') {
+            query.$or = query.$or || [];
+            let orContainsQuery = {};
+            orContainsQuery[field] = new RegExp(v, 'i');
+            query.$or.push(orContainsQuery);
           } else if (op === '|in') {
             query.$or = query.$or || [];
             let orInQuery = {};

--- a/test/findAll.spec.js
+++ b/test/findAll.spec.js
@@ -46,6 +46,35 @@ describe('DSMongoDBAdapter#findAll', function () {
       assert.isFalse(!!destroyedUser);
     });
   });
+  it('should filter users using the "contains" operator', function () {
+    var id;
+
+    return adapter.findAll(User, {
+      where: {
+        name: {
+          'contains': 'J'
+        }
+      }
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, {name: 'John'});
+    }).then(function (user) {
+      id = user._id;
+      return adapter.findAll(User, {
+        where: {
+          name: {
+            'contains': 'J'
+          }
+        }
+      });
+    }).then(function (users) {
+      assert.equal(users.length, 1);
+      assert.equalObjects(users[0], {_id: id, name: 'John'});
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });
   it('should load belongsTo relations', function () {
     return adapter.create(Profile, {
       email: 'foo@test.com'


### PR DESCRIPTION
I've made the query case-insensitive. I guess it would be better for this to be an option, but I couldn't see a reasonable way to do that.

I also updated the version of babel-core, since 5.6.17 couldn't be found.

Thanks.
